### PR TITLE
fix(s3): add dependency

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -4,10 +4,11 @@ resource "aws_s3_bucket" "oidc" {
 }
 
 resource "aws_s3_bucket_object" "oidc_discovery" {
-  bucket  = var.oidc_s3_bucket_name
-  key     = "/.well-known/openid-configuration"
-  acl     = "public-read"
-  content = <<EOF
+  depends_on = [aws_s3_bucket.oidc]
+  bucket     = var.oidc_s3_bucket_name
+  key        = "/.well-known/openid-configuration"
+  acl        = "public-read"
+  content    = <<EOF
 {
   "issuer": "https://${aws_s3_bucket.oidc.bucket_domain_name}/",
   "jwks_uri": "https://${aws_s3_bucket.oidc.bucket_domain_name}/jwks.json",
@@ -30,10 +31,11 @@ EOF
 }
 
 resource "aws_s3_bucket_object" "oidc_jwks" {
-  bucket = var.oidc_s3_bucket_name
-  key    = "/jwks.json"
-  acl    = "public-read"
-  source = var.oidc_jwks_filename
+  depends_on = [aws_s3_bucket.oidc]
+  bucket     = var.oidc_s3_bucket_name
+  key        = "/jwks.json"
+  acl        = "public-read"
+  source     = var.oidc_jwks_filename
 }
 
 resource "aws_iam_openid_connect_provider" "irsa" {


### PR DESCRIPTION
To avoid:

```bash
Error: Error putting object in S3 bucket (oidc-de999d60-ea43-ee00-2b6e-9ec9e9d8433d): NoSuchBucket: The specified bucket does not exist
	status code: 404, request id: 5685FDA29085E20F, host id: +57iQ914O4W9H10DWHb19QKcAeCJJiUUt5l8gxJ5cidAKQelk7XP+GJ98nQQST1sWhQQP/CAJJg=
```
